### PR TITLE
Fix: Prevent query on missing 'roles' table in AuthServiceProvider

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,14 +23,16 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        $roles = Role::all();
+        if (Schema::hasTable('roles')) {
+            $roles = Role::all();
 
-        foreach ($roles as $role) {
-            Gate::define('is_' . $role->name, function (User $user) use ($role) {
-                return $user->hasRole($role);
-            });
+            foreach ($roles as $role) {
+                Gate::define('is_' . $role->name, function (User $user) use ($role) {
+                    return $user->hasRole($role);
+                });
+            }
+
+            Paginator::useBootstrapFive();
         }
-
-        Paginator::useBootstrapFive();
     }
 }


### PR DESCRIPTION
Fix AuthServiceProvider error when 'roles' table is missing  
- Added Schema::hasTable() check to prevent migration issues  
- Resolves Base table not found error  
